### PR TITLE
Added support AuroraOS in Godot 3.6 with Mono

### DIFF
--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -59,15 +59,15 @@ def copy_file(src_dir, dst_dir, src_name, dst_name=""):
 
 
 def is_desktop(platform):
-    return platform in ["windows", "osx", "x11", "server", "uwp", "haiku"]
+    return platform in ["windows", "osx", "x11", "server", "uwp", "haiku", "auroraos"]
 
 
 def is_unix_like(platform):
-    return platform in ["osx", "x11", "server", "android", "haiku", "iphone"]
+    return platform in ["osx", "x11", "server", "android", "haiku", "iphone", "auroraos"]
 
 
 def module_supports_tools_on(platform):
-    return platform not in ["android", "javascript", "iphone"]
+    return platform not in ["android", "javascript", "iphone", "auroraos"]
 
 
 def find_wasm_src_dir(mono_root):
@@ -83,6 +83,7 @@ def find_wasm_src_dir(mono_root):
 
 def configure(env, env_mono):
     bits = env["bits"]
+    is_auroraos = env["platform"] == "auroraos"
     is_android = env["platform"] == "android"
     is_javascript = env["platform"] == "javascript"
     is_ios = env["platform"] == "iphone"
@@ -291,7 +292,7 @@ def configure(env, env_mono):
                             copy_mono_lib("libmono-icall-table")
                             copy_mono_lib("libmono-ilgen")
                 else:
-                    assert is_desktop(env["platform"]) or is_android or is_javascript
+                    assert is_desktop(env["platform"]) or is_android or is_javascript or is_auroraos
                     env.Append(LINKFLAGS=["-Wl,-whole-archive", mono_lib_file, "-Wl,-no-whole-archive"])
 
                 if is_javascript:
@@ -568,7 +569,22 @@ def copy_mono_shared_libs(env, mono_root, target_mono_root_dir):
                     "libMonoSupportW",
                 ]
             ]
-
+        #Эти изменения необходимо проверить
+        elif platform == "auroraos":
+            lib_file_names = [
+                lib_name + ".so"
+                for lib_name in [
+                    "libmonosgen-2.0",
+                    "libmono-btls-shared",
+                    "libmono-ee-interp",
+                    "libmono-native",
+                    "libMonoPosixHelper",
+                    "libmono-profiler-aot",
+                    "libmono-profiler-coverage",
+                    "libmono-profiler-log",
+                    "libMonoSupportW",
+                ]
+            ]
         for lib_file_name in lib_file_names:
             copy_if_exists(os.path.join(src_mono_lib_dir, lib_file_name), target_mono_lib_dir)
 

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -1,4 +1,4 @@
-supported_platforms = ["windows", "osx", "x11", "server", "android", "haiku", "javascript", "iphone"]
+supported_platforms = ["windows", "osx", "x11", "server", "android", "haiku", "javascript", "iphone", "auroraos"]
 
 
 def can_build(env, platform):

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -384,7 +384,7 @@ namespace GodotTools.Export
         private static bool PlatformHasTemplateDir(string platform)
         {
             // OSX export templates are contained in a zip, so we place our custom template inside it and let Godot do the rest.
-            return !new[] { OS.Platforms.OSX, OS.Platforms.Android, OS.Platforms.iOS, OS.Platforms.HTML5 }.Contains(platform);
+            return !new[] { OS.Platforms.OSX, OS.Platforms.Android, OS.Platforms.iOS, OS.Platforms.HTML5, OS.Platforms.AuroraOS }.Contains(platform);
         }
 
         private static bool DeterminePlatformFromFeatures(IEnumerable<string> features, out string platform)
@@ -458,6 +458,7 @@ namespace GodotTools.Export
                 case OS.Platforms.OSX:
                 case OS.Platforms.X11:
                 case OS.Platforms.Server:
+                case OS.Platforms.AuroraOS:
                 case OS.Platforms.Haiku:
                     return "net_4_x";
                 case OS.Platforms.Android:

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
@@ -29,6 +29,7 @@ namespace GodotTools.Utils
             public const string Android = "Android";
             public const string iOS = "iOS";
             public const string HTML5 = "HTML5";
+            public const string AuroraOS = "AuroraOS";
         }
 
         public static class Platforms
@@ -42,6 +43,7 @@ namespace GodotTools.Utils
             public const string Android = "android";
             public const string iOS = "iphone";
             public const string HTML5 = "javascript";
+            public const string AuroraOS = "auroraos";
         }
 
         public static readonly Dictionary<string, string> PlatformNameMap = new Dictionary<string, string>
@@ -54,7 +56,8 @@ namespace GodotTools.Utils
             [Names.Haiku] = Platforms.Haiku,
             [Names.Android] = Platforms.Android,
             [Names.iOS] = Platforms.iOS,
-            [Names.HTML5] = Platforms.HTML5
+            [Names.HTML5] = Platforms.HTML5,
+            [Names.AuroraOS] = Platforms.AuroraOS
         };
 
         private static bool IsOS(string name)
@@ -77,6 +80,7 @@ namespace GodotTools.Utils
         private static readonly Lazy<bool> _isiOS = new Lazy<bool>(() => IsOS(Names.iOS));
         private static readonly Lazy<bool> _isHTML5 = new Lazy<bool>(() => IsOS(Names.HTML5));
         private static readonly Lazy<bool> _isUnixLike = new Lazy<bool>(() => IsAnyOS(UnixLikePlatforms));
+        private static readonly Lazy<bool> _isAuroraOS = new Lazy<bool>(() => IsOS(Names.AuroraOS));
 
         public static bool IsWindows => _isWindows.Value || IsUWP;
         public static bool IsOSX => _isOSX.Value;
@@ -87,8 +91,9 @@ namespace GodotTools.Utils
         public static bool IsAndroid => _isAndroid.Value;
         public static bool IsiOS => _isiOS.Value;
         public static bool IsHTML5 => _isHTML5.Value;
+        public static bool IsAuroraOS => _isAuroraOS.Value;
 
-        private static readonly string[] UnixLikePlatforms = {Names.OSX, Names.X11, Names.Server, Names.Haiku, Names.Android, Names.iOS};
+        private static readonly string[] UnixLikePlatforms = {Names.OSX, Names.X11, Names.Server, Names.Haiku, Names.Android, Names.iOS, Names.AuroraOS};
 
         public static bool IsUnixLike => _isUnixLike.Value;
 

--- a/platform/auroraos/AURORAOS_MONO.md
+++ b/platform/auroraos/AURORAOS_MONO.md
@@ -1,0 +1,215 @@
+# Build the engine and export templates for AuroraOS with Mono support
+
+First of all, download the source code of the engine to the Aurora working directory and assemble the engine and editor from the source code. This instruction used the Godot 3.6 version ported by sashikknox and slightly modified by me for use with mono.
+
+## Installing dependencies on the desktop
+
+**[Official instructions and list of dependencies](https://docs .godotengine.org/ru/3.x/development/compiling/index.html).**
+
+The official documentation also describes in more detail how to build the engine for the main Desktop platforms with Mono. Below is a short instruction for Linux
+
+## Downloading the engine sources and assembling them
+
+My path for executing the `git clone` command is: `~/Aurora/src/`
+
+```
+git clone https://gitflic.ru/project/folgore/godot.git
+cd godot
+scons p=x11 tools=yes module_mono_enabled=yes mono_glue=no
+bin/godot.x11.tools.64.mono --generate-mono-glue modules/mono/glue
+scons p=x11 target=release_debug tools=yes module_mono_enabled=yes
+strip bin/godot.x11.opt.tools.64.mono
+```
+
+**Be sure to make a backup copy of the virtual machine before further manipulations, if you doubt your actions and my instructions.**
+
+## Installing dependencies on the Aurora build engine
+
+P.S. The build was made under AuroraOS-4.0.2.303, so the targets in the instructions are `AuroraOS-4.0.2.303-base-i486` and `AuroraOS-4.0.2.303-base-armv7hl`, use your names for other targets.
+
+### **i486**
+
+Preparing the build engine for compiling godot export templates and working with mono on the emulator
+We launch the terminal from the Aurora working directory. I have this `~/Aurora/`
+
+```
+sfdk engine exec sb2 -t AuroraOS-4.0.2.303-base-i486 -m sdk-install -R zypper --non-interactive install git autoconf libtool make gettext zlib gcc gdb gcc-c++ openssl-devel bzip2-devel xz-devel nano scons mesa-llvmpipe-libGLESv1-devel alsa-lib-devel pulseaudio-devel SDL2-devel SDL2_image-devel SDL2_net-devel SDL2_sound-devel SDL2_ttf-devel wayland-devel wayland-egl-devel wayland-protocols-devel openssl
+```
+
+### Mono Build
+
+Download the mono sources to the Aurora working directory from the official website or from github (I tested the latest version from the Mono website **[12/6/11999](https://download.mono-project.com/sources/mono/mono-6.12.0.199.tar.xz ))**
+*For an example. My path to the source archive is: `~/Aurora/src/mono/`*
+``
+tar -xvf ~/Aurora/src/mono/mono-12/6/11999.tar.xz -C ~/Aurora/src/mono/
+``
+Open the console from the mono source folder and go into the build engine and the emulator target
+
+```
+sfdk engine exec
+sb2 -t AuroraOS-4.0.2.303-base-i486 -m sdk-install -R
+```
+
+Mono is built for the emulator and x86 devices using the following commands
+
+```
+./configure --prefix=/home/mersdk/mono_x86
+make
+make install
+make clean
+```
+*Specify the prefix for installation in a specific folder. Since Mono is assembled in this manual for all SDK 4.02.303 targets, it is necessary that different files for different architectures get along with each other*
+
+Creating a script for exporting global parameters:
+
+```
+nano ~/.mono_x86
+```
+
+Script Content:
+
+```
+#!/bin/bash
+
+#Path to prefix with mono for i486
+MONO_PREFIX=/home/mersdk/mono_x86
+
+export DYLD_FALLBACK_LIBRARY_PATH=$MONO_PREFIX/lib:$DYLD_LIBRARY_FALLBACK_PATH
+export LD_LIBRARY_PATH=$MONO_PREFIX/lib:$LD_LIBRARY_PATH
+export C_INCLUDE_PATH=$MONO_PREFIX/include
+export ACLOCAL_PATH=$MONO_PREFIX/share/aclocal
+export PKG_CONFIG_PATH=$MONO_PREFIX/lib/pkgconfig
+export PATH=$MONO_PREFIX/bin:$PATH
+```
+
+Exporting variables
+
+```
+source ~/.mono_x86
+```
+
+We are synchronizing certificates so that nuget can be used in future projects, for example.
+
+```
+cert-sync /etc/ssl/certs/ca-bundle.crt
+```
+
+We write the exit command twice to exit the target console and the build engine.
+
+```
+exit
+exit
+```
+
+Go to the Godot source folder to compile the export templates.
+
+```
+cd ~/Aurora/src/godot
+```
+
+*If it is necessary to encrypt .pck scripts, then it is necessary to act according to [instructions](https://docs .godotengine.org/ru/3.x/development/compiling/compiling_with_script_encryption_key.html ) posted on the Godot website*
+
+In the Godot source folder, run the commands to build the release and debug template (the second one, if necessary)
+
+### Building a release export template
+
+```
+sfdk engine exec sb2 -t AuroraOS-4.0.2.303-base-i486 scons -j`nproc` arch=x86 platform=auroraos tools=no bits=32 target=release module_mono_enabled=yes mono_prefix="/home/mersdk/mono_x86/" mono_static=yes
+```
+
+### Building the debug export template
+
+```
+sfdk engine exec sb2 -t AuroraOS-4.0.2.303-base-i486 scons -j`nproc` arch=x86 platform=auroraos tools=no bits=32 target=debug module_mono_enabled=yes mono_prefix="/home/mersdk/mono_x86/" mono_static=yes
+```
+
+`module_mono_enabled=yes` activates the ability to use mono and the C# language to write scripts.
+We pay special attention to `mono_prefix`, since the path must match the previously specified path when compiling Mono.
+`mono_static=yes` is required, otherwise libraries such as `libmonosgen-2.0.so ` it will be necessary to somehow upload the project to the device, bypassing the validator.
+
+After compilation, the file `godot.auroraos.opt.x86.mono` and the folder `data.mono.auroraos` will appear in the `bin' folder located in the downloaded Godot sources.32.release` (if you specified `target=debug`, then the file and folder will have the corresponding entry in the name).
+We specify this file in the export settings when exporting the project. If you move the templates, be sure to copy the corresponding folder (indicated above), it contains the necessary libraries, which will be included in the project when exporting.
+
+### Feature of Mono compilation under ARM
+Installing the necessary dependencies for armv7hl
+
+```
+sfdk engine exec sb2 -t AuroraOS-4.0.2.303-base-armv7hl -m sdk-install -R zypper --non-interactive install git autoconf libtool make gettext zlib gcc gdb gcc-c++ openssl-devel bzip2-devel xz-devel nano scons mesa-llvmpipe-libGLESv1-devel alsa-lib-devel pulseaudio-devel SDL2-devel SDL2_image-devel SDL2_net-devel SDL2_sound-devel SDL2_ttf-devel wayland-devel wayland-egl-devel wayland-protocols-devel openssl
+```
+Go to the mono source folder
+
+```
+cd ~/Aurora/src/mono/mono-6.12.0.199
+```
+Launching the assembly engine terminal from the catalog
+
+```
+sfdk engine exec
+sb2 -t AuroraOS-4.0.2.303-base-armv7hl
+``
+### Mono Build
+``
+./configure --prefix=/home/mersdk/mono_arm --disable-mcs-build
+make
+make install
+make clean
+```
+Here we have specified a different path for the prefix, different from the previous one for the emulator and x86, and we also make sure to write `--disable-mcs-build`
+
+Creating a script for exporting global parameters
+
+```
+nano ~/.mono_arm
+```
+
+File contents:
+``
+#!/bin/bash
+
+#Path to prefix with mono for arm
+MONO_PREFIX=/home/mersdk/mono_arm
+
+export DYLD_FALLBACK_LIBRARY_PATH=$MONO_PREFIX/lib:$DYLD_LIBRARY_FALLBACK_PATH
+export LD_LIBRARY_PATH=$MONO_PREFIX/lib:$LD_LIBRARY_PATH
+export C_INCLUDE_PATH=$MONO_PREFIX/include
+export ACLOCAL_PATH=$MONO_PREFIX/share/aclocal
+export PKG_CONFIG_PATH=$MONO_PREFIX/lib/pkgconfig
+export PATH=$MONO_PREFIX/bin:$PATH
+```
+
+**Before compiling the sources for arm, I recommend turning off the assembly engine, and running it again and exporting global variables for this platform, so that the mono_x86 and mono_arm variables do not mix.**
+
+```
+sfdk engine exec
+sb2 -t AuroraOS-4.0.2.303-base-armv7hl -m sdk-install -R
+source /home/mersdk/.mono_arm
+exit
+exit
+```
+
+*`/home/mersdk/` - the VM's home directory*
+
+### Creating export templates
+
+go to the Godot source folder
+
+```
+cd ~/Aurora/src/godot
+```
+
+### Build a release 32bit export template
+
+``
+sfdk engine exec sb2 -t AuroraOS-4.0.2.303-base-armv7hl scons -j'nproc` arch=arm platform=auroraos tools=no bits=32 target=release module_mono_enabled=yes mono_prefix="/home/mersdk/mono_arm/" mono_static=yes
+``
+### Export template build debug 32bit
+
+```
+sfdk engine exec sb2 -t AuroraOS-4.0.2.303-base-armv7hl scons -j`nproc` arch=arm platform=auroraos tools=no bits=32 target=release module_mono_enabled=yes mono_prefix="/home/mersdk/mono_arm/" mono_static=yes
+```
+
+*The export template for arm will take much longer to create…*
+
+The other export templates are compiled in the same way.
+
+Instructions for using export templates from Sashikknox to Godot can be found [here](https://boosty.to/sashikknox/posts/bad1c63b-c453-4933-a34c-ee7c22bd6e44 ?share=post_link)


### PR DESCRIPTION
Added support for using **Godot 3.6 Mono** to make project for **AuroraOS**
Instruction in `platform/auroraos/AURORAOS_MONO.md` file